### PR TITLE
Ignore `docker rm src` error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: archive
 
 clean:
 	rm -rf compile/lambda.zip
-	docker rm src
+	-docker rm src
 
 archive: clean
 ifeq ($(circleci), true)


### PR DESCRIPTION
When you start with clean environment, you will not have src container. Hence you will end up with container does not error.
I think it is safe to ignore this error.